### PR TITLE
Refactor TaskList find method to use streams

### DIFF
--- a/src/main/java/mana/util/TaskList.java
+++ b/src/main/java/mana/util/TaskList.java
@@ -3,8 +3,8 @@ package mana.util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 import mana.tasks.Task;
 
@@ -49,22 +49,12 @@ public class TaskList {
     }
 
     public List<ImmutablePair<Integer, Task>> find(String substring) {
-        List<ImmutablePair<Integer, Task>> matches = new ArrayList<>();
         Pattern p = Pattern.compile(substring);
-        for (int i = 0; i < tasks.size(); i++) {
-            boolean match = false;
-            String title = tasks.get(i).getTitle();
-            if (title.length() < 32) {
-                match = title.indexOf(substring) > 0;
-            } else {
-                Matcher m = p.matcher(title);
-                match = m.find();
-            }
-            if (match) {
-                matches.add(ImmutablePair.of(i, tasks.get(i)));
-            }
-        }
-        return matches;
+        return IntStream.range(0, tasks.size())
+                .mapToObj(i -> ImmutablePair.of(i, tasks.get(i)))
+                .filter(idxTask -> idxTask.second != null)
+                .filter(idxTask -> p.matcher(idxTask.second.getTitle()).find())
+                .toList();
     }
 
     public String getTitle() {


### PR DESCRIPTION
Current TaskList find method uses an indexed for loop and multiple conditions to check for title match.

This is overtly verbose and confusing to navigate due to premature optimisation.

Changing the search logic to use streams results in cleaner and more readable code.